### PR TITLE
Add test to compare days

### DIFF
--- a/index.test.js
+++ b/index.test.js
@@ -8,6 +8,26 @@ test("returns the same result for the same day", () => {
   assert.equal(ofTheDay(data), ofTheDay(data));
 });
 
+test("returns a different result for a different day", () => {
+  const n = data.length;
+  const today = new Date();
+  const anotherDay = new Date(today);
+  if (today.getDate() === 1) {
+    anotherDay.setDate(2);
+  } else {
+    anotherDay.setDate(1);
+  }
+
+  const anotherDayISO = anotherDay.toISOString();
+  const todaysResult = ofTheDay(data, n);
+  const originalToISOString = Date.prototype.toISOString;
+  Date.prototype.toISOString = () => anotherDayISO;
+  const anotherDaysResult = ofTheDay(data, n);
+  Date.prototype.toISOString = originalToISOString;
+
+  assert.not.equal(todaysResult, anotherDaysResult);
+});
+
 test("WHEN n IS PROVIDED, returns array of length n", () => {
   assert.is(ofTheDay(data, 2).length, 2);
 });


### PR DESCRIPTION
This PR adds a test that compares the results of `ofTheDay()` for two different days. This case gives us confidence that the library is working as expected when generating responses on different days.